### PR TITLE
Update Overworld/Dungeons Keysanity for Dev-R-test-settings. 

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1174,6 +1174,8 @@ hintTable = {
 
     'ganonBK_dungeon':                                          ("hidden somewhere #inside its castle#", None, 'ganonBossKey'),
     'ganonBK_vanilla':                                          ("kept in a big chest #inside its tower#", None, 'ganonBossKey'),
+    'ganonBK_overworld':                                        ("hidden outside of dungeons #in Hyrule#", None, 'ganonBossKey'),
+    'ganonBK_dungeons':                                         ("hidden inside a dungeon #in Hyrule#", None, 'ganonBossKey'),
     'ganonBK_keysanity':                                        ("hidden somewhere #in Hyrule#", None, 'ganonBossKey'),
     'ganonBK_triforce':                                         ("given to the Hero once the #Triforce# is completed", None, 'ganonBossKey'),
 


### PR DESCRIPTION
Overworld and Any Dungeon for Ganon's BK needs to disable all of the irrelevant settings for Stone/Medallion/Dungeon/Token count.

**Note:** Also includes the Dev-R commit for pedestal hints, the -test-settings commit itself is technically a merge commit.