### PR TITLE
Fixed skull mask hint being removed from tournament_s3

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -97,7 +97,7 @@ def getRequiredHints(world):
 # Hints required under certain settings
 conditional_always = {
     'Market 10 Big Poes':           lambda world: world.big_poe_count > 3,
-    'Deku Theater Skull Mask':      lambda world: world.hint_dist == 'tournament' and world.open_kakariko == 'closed' and not world.complete_mask_quest,
+    'Deku Theater Skull Mask':      lambda world: world.hint_dist in ('tournament_s3', 'tournament') and world.open_kakariko == 'closed' and not world.complete_mask_quest,
     'Deku Theater Mask of Truth':   lambda world: not world.complete_mask_quest,
     'Song from Ocarina of Time':    lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),
     'HF Ocarina of Time Item':      lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),


### PR DESCRIPTION
When the tournament hints were replaced, this line was not updated. Causes skull mask to not be an always hint in tournament_s3.