### PR TITLE
Ensure that each one way entrance (owl drop, spawn, or warp song) leads to a different region

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -600,8 +600,8 @@ def check_entrances_compatibility(entrance, target, rollbacks):
     if entrance.parent_region.get_scene() and entrance.parent_region.get_scene() == target.connected_region.get_scene():
         raise EntranceShuffleError('Self scene connections are forbidden')
 
-    # Warp songs shouldn't lead to the same scene as other warp songs
-    if entrance.type == 'WarpSong' and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
+    # One way entrances shouldn't lead to the same scene as other already chosen one way entrances
+    if (entrance.type == 'OwlDrop' or entrance.type == 'Spawn' or entrance.type == 'WarpSong') and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
         raise EntranceShuffleError('A warp song already leads to %s' % target.connected_region.get_scene())
 
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -602,7 +602,7 @@ def check_entrances_compatibility(entrance, target, rollbacks):
 
     # One way entrances shouldn't lead to the same scene as other already chosen one way entrances
     if (entrance.type == 'OwlDrop' or entrance.type == 'Spawn' or entrance.type == 'WarpSong') and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
-        raise EntranceShuffleError('A warp song already leads to %s' % target.connected_region.get_scene())
+        raise EntranceShuffleError('%s entrance already leads to %s' % (entrance.type, target.connected_region.get_scene()))
 
 
 # Validate the provided worlds' structures, raising an error if it's not valid based on our criterias

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -444,7 +444,9 @@ def shuffle_random_entrances(worlds):
 
         # Shuffle all entrances among the pools to shuffle
         for pool_type, entrance_pool in one_way_entrance_pools.items():
-            shuffle_entrance_pool(world, worlds, entrance_pool, one_way_target_entrance_pools[pool_type], locations_to_ensure_reachable, check_all=True)
+            # Ensure that each warp song leads to a different region
+            target_entrances = sample_target_entrances(one_way_target_entrance_pools[pool_type]) if pool_type == 'WarpSong' else one_way_target_entrance_pools[pool_type]
+            shuffle_entrance_pool(world, worlds, entrance_pool, target_entrances, locations_to_ensure_reachable, check_all=True)
             # Delete all targets that we just placed from other one way target pools so multiple one way entrances don't use the same target
             replaced_entrances = [entrance.replaces for entrance in entrance_pool]
             for remaining_target in chain.from_iterable(one_way_target_entrance_pools.values()):
@@ -754,3 +756,9 @@ def delete_target_entrance(target_entrance):
     if target_entrance.parent_region != None:
         target_entrance.parent_region.exits.remove(target_entrance)
         target_entrance.parent_region = None
+
+
+# Sample the given list of target entrances such that each entrance has a different connected region
+def sample_target_entrances(target_entrances):
+    sample = random.sample(target_entrances, len(target_entrances))
+    return [target for target in sample if target is next(tt for tt in sample if tt.connected_region is target.connected_region)]

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -602,7 +602,7 @@ def check_entrances_compatibility(entrance, target, rollbacks):
 
     # One way entrances shouldn't lead to the same scene as other already chosen one way entrances
     if (entrance.type == 'OwlDrop' or entrance.type == 'Spawn' or entrance.type == 'WarpSong') and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
-        raise EntranceShuffleError('%s entrance already leads to %s' % (entrance.type, target.connected_region.get_scene()))
+        raise EntranceShuffleError('%s is already reachable via another %s' % (target.connected_region.get_scene(), entrance.type))
 
 
 # Validate the provided worlds' structures, raising an error if it's not valid based on our criterias

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -602,7 +602,7 @@ def check_entrances_compatibility(entrance, target, rollbacks):
 
     # One way entrances shouldn't lead to the same scene as other already chosen one way entrances
     if (entrance.type == 'OwlDrop' or entrance.type == 'Spawn' or entrance.type == 'WarpSong') and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
-        raise EntranceShuffleError('%s is already reachable via another %s' % (target.connected_region.get_scene(), entrance.type))
+        raise EntranceShuffleError('Another %s already leads to %s' % (entrance.type, target.connected_region.get_scene()))
 
 
 # Validate the provided worlds' structures, raising an error if it's not valid based on our criterias

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -444,9 +444,7 @@ def shuffle_random_entrances(worlds):
 
         # Shuffle all entrances among the pools to shuffle
         for pool_type, entrance_pool in one_way_entrance_pools.items():
-            # Ensure that each warp song leads to a different region
-            target_entrances = sample_target_entrances(one_way_target_entrance_pools[pool_type]) if pool_type == 'WarpSong' else one_way_target_entrance_pools[pool_type]
-            shuffle_entrance_pool(world, worlds, entrance_pool, target_entrances, locations_to_ensure_reachable, check_all=True)
+            shuffle_entrance_pool(world, worlds, entrance_pool, one_way_target_entrance_pools[pool_type], locations_to_ensure_reachable, check_all=True)
             # Delete all targets that we just placed from other one way target pools so multiple one way entrances don't use the same target
             replaced_entrances = [entrance.replaces for entrance in entrance_pool]
             for remaining_target in chain.from_iterable(one_way_target_entrance_pools.values()):
@@ -580,7 +578,7 @@ def shuffle_entrances(worlds, entrances, target_entrances, rollbacks, locations_
                 continue
 
             try:
-                check_entrances_compatibility(entrance, target)
+                check_entrances_compatibility(entrance, target, rollbacks)
                 change_connections(entrance, target)
                 validate_world(entrance.world, worlds, entrance, locations_to_ensure_reachable, complete_itempool)
                 rollbacks.append((entrance, target))
@@ -597,10 +595,14 @@ def shuffle_entrances(worlds, entrances, target_entrances, rollbacks, locations_
 
 
 # Check and validate that an entrance is compatible to replace a specific target
-def check_entrances_compatibility(entrance, target):
+def check_entrances_compatibility(entrance, target, rollbacks):
     # An entrance shouldn't be connected to its own scene, so we fail in that situation
     if entrance.parent_region.get_scene() and entrance.parent_region.get_scene() == target.connected_region.get_scene():
         raise EntranceShuffleError('Self scene connections are forbidden')
+
+    # Warp songs shouldn't lead to the same scene as other warp songs
+    if entrance.type == 'WarpSong' and any([rollback[0].connected_region.get_scene() == target.connected_region.get_scene() for rollback in rollbacks]):
+        raise EntranceShuffleError('A warp song already leads to %s' % target.connected_region.get_scene())
 
 
 # Validate the provided worlds' structures, raising an error if it's not valid based on our criterias
@@ -756,9 +758,3 @@ def delete_target_entrance(target_entrance):
     if target_entrance.parent_region != None:
         target_entrance.parent_region.exits.remove(target_entrance)
         target_entrance.parent_region = None
-
-
-# Sample the given list of target entrances such that each entrance has a different connected region
-def sample_target_entrances(target_entrances):
-    sample = random.sample(target_entrances, len(target_entrances))
-    return [target for target in sample if target is next(tt for tt in sample if tt.connected_region is target.connected_region)]


### PR DESCRIPTION
Problem: Warp song entrance randomizer often results in many of the songs leading to the same region, especially in areas with many entrances, such as Kakariko Village and Market.

Solution: Attempt to spread out the warp song entrances (in the spirit of the vanilla game) by randomly sampling the target entrances for warp song ER such that each has a different connected region.

Pros: This fixes the examples in the problem statement.

Cons: It's still possible for warp song entrances to be nearby each other in several ways:
- A region is split into multiple regions (e.g., DMC is split into upper, lower, and central regions), so multiple warps lead to DMC
- Two warp songs lead to both sides of an entrance (e.g., KF and KF Sarias House) with or without interior or exterior ER