### PR TITLE
Allow reverse overworld entrances to be used in plando with full mixed pools

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -531,7 +531,7 @@ class WorldDistribution(object):
             entrance_found = False
             for pool_type, entrance_pool in entrance_pools.items():
                 try:
-                    matched_entrance = next(filter(lambda entrance: (entrance.name == name or (entrance.reverse and entrance.reverse.name == name)), entrance_pool))
+                    matched_entrance = next(filter(lambda entrance: (entrance.name == name or (entrance.reverse and entrance.reverse.name == name and not worlds[self.id].decouple_entrances)), entrance_pool))
                 except StopIteration:
                     continue
 
@@ -542,7 +542,7 @@ class WorldDistribution(object):
 
                 entrance_found = True
                 if matched_entrance.connected_region != None:
-                    if matched_entrance.type == 'Overworld' or (pool_type == 'Mixed' and matched_entrance.replaces.type) == 'Overworld':
+                    if matched_entrance.type == 'Overworld' or (pool_type == 'Mixed' and matched_entrance.replaces.type == 'Overworld'):
                         continue
                     else:
                         raise RuntimeError('Entrance already shuffled in world %d: %s' % (self.id + 1, name))
@@ -550,7 +550,7 @@ class WorldDistribution(object):
                 target_region = record.region
                 
                 matched_targets_to_region = list(filter(lambda target: (target.connected_region and target.connected_region.name == target_region)
-                                                        or (target.reverse and target.reverse.connected_region and target.reverse.connected_region.name == target_region), 
+                                                        or (target.reverse and target.reverse.connected_region and target.reverse.connected_region.name == target_region and not worlds[self.id].decouple_entrances), 
                                                         target_entrance_pools[pool_type]))
                 if not matched_targets_to_region:
                     raise RuntimeError('No entrance found to replace with %s that leads to %s in world %d' % 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -531,24 +531,37 @@ class WorldDistribution(object):
             entrance_found = False
             for pool_type, entrance_pool in entrance_pools.items():
                 try:
-                    matched_entrance = next(filter(lambda entrance: entrance.name == name, entrance_pool))
+                    matched_entrance = next(filter(lambda entrance: (entrance.name == name or (entrance.reverse and entrance.reverse.name == name)), entrance_pool))
                 except StopIteration:
                     continue
 
+                if matched_entrance.type == 'Overworld' and matched_entrance.name != name:
+                    reverse_entrance = matched_entrance
+                    matched_entrance = matched_entrance.reverse
+                    matched_entrance.reverse = reverse_entrance
+
                 entrance_found = True
                 if matched_entrance.connected_region != None:
-                    if matched_entrance.type == 'Overworld':
+                    if matched_entrance.type == 'Overworld' or (pool_type == 'Mixed' and matched_entrance.replaces.type) == 'Overworld':
                         continue
                     else:
                         raise RuntimeError('Entrance already shuffled in world %d: %s' % (self.id + 1, name))
 
                 target_region = record.region
-
-                matched_targets_to_region = list(filter(lambda target: target.connected_region and target.connected_region.name == target_region, 
+                
+                matched_targets_to_region = list(filter(lambda target: (target.connected_region and target.connected_region.name == target_region)
+                                                        or (target.reverse and target.reverse.connected_region and target.reverse.connected_region.name == target_region), 
                                                         target_entrance_pools[pool_type]))
                 if not matched_targets_to_region:
                     raise RuntimeError('No entrance found to replace with %s that leads to %s in world %d' % 
                                                 (matched_entrance, target_region, self.id + 1))
+                index = 0
+                while index < len(matched_targets_to_region):
+                    if (matched_targets_to_region[index].connected_region and matched_targets_to_region[index].connected_region.name != target_region) or (matched_targets_to_region[index].connected_region is None):
+                        reverse_target = matched_targets_to_region[index]
+                        matched_targets_to_region[index] = matched_targets_to_region[index].reverse
+                        matched_targets_to_region[index].reverse = reverse_target
+                    index += 1
 
                 if record.origin:
                     target_parent = record.origin


### PR DESCRIPTION
Entrance pools for setting plando'd entrances only include one side of overworld entrances as top level keys. This fails seed generation when the opposite direction is specified. The PR adds searches on the .reverse property of the primary entrances, then swaps variables as necessary to link the right entrances.

Tested on 50 random settings seeds with forced full mixed pools, another 50 random settings seeds with forced indoor-only mixed pools, and a final 50 with no mixed pools by generating a seed and feeding the spoiler back into the randomizer as a plando. Decoupled was tested with full mixed only for 50 random settings seeds. The only modifications to the plando are removing fixed shop items from locations, the item pool, and hints. The two attached plandos were used for development and testing:

[Full mixed, only OW ER on](https://github.com/Roman971/OoT-Randomizer/files/6873068/error_plando_Spoiler2021-07-24_05-07-34_772218.txt)
[Full mixed, OW, All Indoor, Dungeon ER on](https://github.com/Roman971/OoT-Randomizer/files/6873069/error_plando_Spoiler2021-07-24_17-13-01_382975.txt)

There are some remaining issues with world validation that this PR does not address. This includes invalid starting area, ToD passing access as both ages, ToT access guarantee as opposite age, and Biggoron access (maybe any always-hinted location?). When these came up in testing, I verified that the plando had the same error in the unmodified branch.