### PR TITLE
Changed random keyrings logic

### DIFF
--- a/World.py
+++ b/World.py
@@ -434,7 +434,10 @@ class World(object):
         # Determine area with keyring
         if (self.settings.key_rings_choice == 'random'):
             areas = ['Thieves Hideout', 'Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple', 'Bottom of the Well', 'Gerudo Training Ground', 'Ganons Castle']
-            self.settings.key_rings = random.sample(areas, random.randint(0, len(areas)))
+            num_key_rings = 0
+            for _ in areas:
+                num_key_rings += random.randint(0, 1)
+            self.settings.key_rings = random.sample(areas, num_key_rings)
             self.randomized_list.append('key_rings')
         elif (self.settings.key_rings_choice == 'all'):
             self.settings.key_rings = ['Thieves Hideout', 'Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple', 'Bottom of the Well', 'Gerudo Training Ground', 'Ganons Castle']


### PR DESCRIPTION
Changed random keyrings to roll 50/50 per dungeon similar to how random MQ dungeons are decided.
This makes it more likely for there to be a mix of keyring and non-keyring dungeons, and less likely for there to be either all or no keyrings.